### PR TITLE
Rama jhonson

### DIFF
--- a/patients_diagnoses/serializers/PatientController.py
+++ b/patients_diagnoses/serializers/PatientController.py
@@ -1,0 +1,12 @@
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from patients_diagnoses.serializers.PatientService import PatientService
+
+class PatientController(APIView):
+    
+    def get(self, request):
+        """
+        Lista paginada de pacientes (index)
+        """
+        data = PatientService.getPaginated(request)
+        return Response(data)

--- a/patients_diagnoses/serializers/PatientService.py
+++ b/patients_diagnoses/serializers/PatientService.py
@@ -1,0 +1,113 @@
+from django.core.paginator import Paginator
+from django.db.models import Q
+from patients_diagnoses.models import Patient
+from patients_diagnoses.serializers.patient_serializers import PatientSerializer
+from patients_diagnoses.serializers.search_serializers import SearchPatientsRequest
+
+
+class PatientService:
+
+    @staticmethod
+    def getPaginated(request):
+        patients = Patient.objects.all().order_by('id')
+        page_number = request.GET.get('page', 1)
+        page_size = request.GET.get('per_page', 10)
+
+        paginator = Paginator(patients, page_size)
+        page_obj = paginator.get_page(page_number)
+
+        serializer = PatientSerializer(page_obj, many=True)
+
+        return {
+            'current_page': page_obj.number,
+            'data': serializer.data,
+            'first_page_url': f"{request.path}?page=1",
+            'from': page_obj.start_index(),
+            'last_page': paginator.num_pages,
+            'last_page_url': f"{request.path}?page={paginator.num_pages}",
+            'links': PatientService.build_links(request, paginator, page_obj),
+            'next_page_url': f"{request.path}?page={page_obj.next_page_number()}" if page_obj.has_next() else None,
+            'path': request.build_absolute_uri().split('?')[0],
+            'per_page': int(page_size),
+            'prev_page_url': f"{request.path}?page={page_obj.previous_page_number()}" if page_obj.has_previous() else None,
+            'to': page_obj.end_index(),
+            'total': paginator.count
+        }
+
+    @staticmethod
+    def build_links(request, paginator, page_obj):
+        current_page = page_obj.number
+        last_page = paginator.num_pages
+        links = []
+
+        # Prev
+        links.append({
+            'url': f"{request.path}?page={current_page - 1}" if page_obj.has_previous() else None,
+            'label': '« Previous',
+            'active': False
+        })
+
+        # Pages
+        for i in range(1, min(last_page, 10) + 1):
+            links.append({
+                'url': f"{request.path}?page={i}",
+                'label': str(i),
+                'active': (i == current_page)
+            })
+
+        if last_page > 10:
+            links.append({'url': None, 'label': '...', 'active': False})
+            links.append({'url': f"{request.path}?page={last_page - 1}", 'label': str(last_page - 1), 'active': False})
+            links.append({'url': f"{request.path}?page={last_page}", 'label': str(last_page), 'active': False})
+
+        # Next
+        links.append({
+            'url': f"{request.path}?page={current_page + 1}" if page_obj.has_next() else None,
+            'label': 'Next »',
+            'active': False
+        })
+
+        return links
+
+    @staticmethod
+    def searchByTerm(queryset, term):
+        return queryset.filter(
+            Q(name__icontains=term) |
+            Q(paternal_lastname__icontains=term) |
+            Q(maternal_lastname__icontains=term) |
+            Q(document_number__icontains=term)
+        )
+
+    @staticmethod
+    def searchPatients(request):
+        serializer = SearchPatientsRequest(data=request.GET)
+        serializer.is_valid(raise_exception=True)
+        term = serializer.validated_data.get('term', '')
+        queryset = Patient.objects.all().order_by('id')
+
+        if term:
+            queryset = PatientService.searchByTerm(queryset, term)
+
+        page_number = request.GET.get('page', 1)
+        page_size = request.GET.get('per_page', 10)
+
+        paginator = Paginator(queryset, page_size)
+        page_obj = paginator.get_page(page_number)
+
+        serializer = PatientSerializer(page_obj, many=True)
+
+        return {
+            'current_page': page_obj.number,
+            'data': serializer.data,
+            'first_page_url': f"{request.path}?page=1",
+            'from': page_obj.start_index(),
+            'last_page': paginator.num_pages,
+            'last_page_url': f"{request.path}?page={paginator.num_pages}",
+            'links': PatientService.build_links(request, paginator, page_obj),
+            'next_page_url': f"{request.path}?page={page_obj.next_page_number()}" if page_obj.has_next() else None,
+            'path': request.build_absolute_uri().split('?')[0],
+            'per_page': int(page_size),
+            'prev_page_url': f"{request.path}?page={page_obj.previous_page_number()}" if page_obj.has_previous() else None,
+            'to': page_obj.end_index(),
+            'total': paginator.count
+        }

--- a/patients_diagnoses/serializers/patient_serializers.py
+++ b/patients_diagnoses/serializers/patient_serializers.py
@@ -5,4 +5,14 @@ from ..models import Patient
 class PatientSerializer(serializers.ModelSerializer):
     class Meta:
         model = Patient
-        fields = '__all__'  # O lista explícita si quieres: ['id', 'name', ...]
+        fields = '__all__'  
+class SearchPatientsRequest(serializers.Serializer):
+    document_number = serializers.CharField(required=False, allow_blank=True, max_length=20)
+    name = serializers.CharField(required=False, allow_blank=True, max_length=100)
+    sex = serializers.ChoiceField(choices=['M', 'F'], required=False)
+    region = serializers.IntegerField(required=False)
+    page = serializers.IntegerField(required=False, min_value=1)
+    per_page = serializers.IntegerField(required=False, min_value=1, max_value=100)
+
+    def validate(self, attrs):
+        return attrs


### PR DESCRIPTION
Método getPaginated

Lista todos los pacientes ordenados por ID.

Implementa paginación manual.

Devuelve metadatos útiles como: página actual, total de registros, enlaces de navegación, etc.

Método build_links

Genera dinámicamente los enlaces para la navegación entre páginas (prev, next, números, etc.).

Serializer de validación SearchPatientsRequest

Valida la entrada del usuario para búsquedas, especialmente el campo term.

Método searchByTerm

Filtra pacientes por nombre, apellidos o número de documento usando consultas Q con icontains.

Método searchPatients

Integra la validación del término.

Aplica la búsqueda y paginación de forma combinada.

Retorna los mismos metadatos paginados que getPaginated.